### PR TITLE
fix: subdomain mismatch

### DIFF
--- a/src/clone.ts
+++ b/src/clone.ts
@@ -31,7 +31,7 @@ export const clone = async (opts: { repo: string; dir: string }) => {
 
   let parsedRepo = gitParser(repo)
   const matchedCodebase = config.codebase.find((codebase) => {
-    return parsedRepo.source === codebase.url
+    return parsedRepo.resource === codebase.url
   })
   if (!matchedCodebase) {
     logger.error(`No matched codebase found for repo: ${chalk.red(repo)}`)


### PR DESCRIPTION
source 是 Git provider (e.g. "github.com")，当 config 填 git.example.com 时，source 是 example.com，导致无法匹配，resource 是 url domain (including subdomains)。